### PR TITLE
autogen.sh does not require README file

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,7 +45,7 @@ AC_PREREQ(2.59)
 AC_CONFIG_AUX_DIR([pkg])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CANONICAL_HOST
-AM_INIT_AUTOMAKE([subdir-objects tar-ustar dist-bzip2 dist-xz no-define -Wno-portability ])
+AM_INIT_AUTOMAKE([subdir-objects tar-ustar dist-bzip2 dist-xz no-define -Wno-portability foreign])
 AM_GNU_GETTEXT([external])
 AM_GNU_GETTEXT_VERSION([0.14])
 AC_GNU_SOURCE


### PR DESCRIPTION
Since README file is now README.md, mark with [foreign]
that we do not follow this GNU Standard.

Signed-off-by: Nuno Goncalves <nunojpg@gmail.com>