### PR TITLE
RPM spec file fix and dockerfile to build it in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ po/insert-header.sin
 po/quot.sed
 po/remove-potcdate.sin
 
+# docker build process
+/Dockerfile
+/*-entrypoint.sh

--- a/pkg/build-dockerfile.sh
+++ b/pkg/build-dockerfile.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cur_dir=$(cd $(dirname $0); pwd)
+
+cp $cur_dir/dockerfiles/Dockerfile.${1} $cur_dir/../Dockerfile
+cp $cur_dir/dockerfiles/${1}-entrypoint.sh $cur_dir/../
+docker build -t ${1}-libsmbios -- .

--- a/pkg/dockerfiles/Dockerfile.centos6
+++ b/pkg/dockerfiles/Dockerfile.centos6
@@ -1,0 +1,15 @@
+FROM centos:6
+
+VOLUME /output
+
+ENV OUTPUT_DIR /output
+ENV BUILD_DIR /build
+
+RUN yum install -y \
+  rpm-build gettext-devel libxml2-devel cppunit-devel xz libtool git gcc-c++ hardlink doxygen \
+  && yum clean all
+
+WORKDIR $BUILD_DIR
+COPY . .
+
+CMD ["./centos6-entrypoint.sh"]

--- a/pkg/dockerfiles/centos6-entrypoint.sh
+++ b/pkg/dockerfiles/centos6-entrypoint.sh
@@ -2,3 +2,4 @@
 
 ./pkg/mk-rel-rpm.sh
 cp $BUILD_DIR/_builddir/*.rpm $OUTPUT_DIR
+cp $BUILD_DIR/_builddir/x86_64/*.rpm $OUTPUT_DIR

--- a/pkg/dockerfiles/centos6-entrypoint.sh
+++ b/pkg/dockerfiles/centos6-entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+./pkg/mk-rel-rpm.sh
+cp $BUILD_DIR/_builddir/*.rpm $OUTPUT_DIR

--- a/pkg/libsmbios.spec.in
+++ b/pkg/libsmbios.spec.in
@@ -299,17 +299,15 @@ ln -s %{_sbindir}/dellWirelessCtl %{buildroot}/%{_bindir}/dellWirelessCtl
 ln -s smbios-sys-info %{buildroot}/%{_sbindir}/getSystemId
 ln -s smbios-wireless-ctl %{buildroot}/%{_sbindir}/dellWirelessCtl
 ln -s smbios-lcd-brightness %{buildroot}/%{_sbindir}/dellLcdBrightness
-ln -s smbios-rbu-bios-update %{buildroot}/%{_sbindir}/dellBiosUpdate
 
 cat > files-python-smbios <<-EOF
-	%doc COPYING-GPL COPYING-OSL README
+	%doc COPYING-GPL COPYING-OSL
 	%{python_sitelib}/*
 EOF
 
 cat > files-smbios-utils-python <<-EOF
-	%doc COPYING-GPL COPYING-OSL README
+	%doc COPYING-GPL COPYING-OSL
 	%doc src/bin/getopts_LICENSE.txt src/include/smbios/config/boost_LICENSE_1_0_txt
-	%doc doc/pkgheader.sh
 	%dir %{_sysconfdir}/libsmbios
 	%config(noreplace) %{_sysconfdir}/libsmbios/*
 	
@@ -319,18 +317,17 @@ cat > files-smbios-utils-python <<-EOF
 	%{_sbindir}/smbios-passwd
 	%{_sbindir}/smbios-wakeup-ctl
 	%{_sbindir}/smbios-wireless-ctl
-	%{_sbindir}/smbios-rbu-bios-update
 	%{_sbindir}/smbios-lcd-brightness
 	%{_sbindir}/smbios-keyboard-ctl
 	%{_sbindir}/smbios-thermal-ctl
 	%{_sbindir}/smbios-battery-ctl
 	
-	# symlinks: backwards compat
+	# used by HAL in old location, so keep it around until HAL is updated.
+	%{_sbindir}/dellLEDCtl
 	%{_sbindir}/dellLcdBrightness
+	%{_sbindir}/dellMediaDirectCtl
 	%{_sbindir}/getSystemId
 	%{_sbindir}/dellWirelessCtl
-	%{_sbindir}/dellBiosUpdate
-	# used by HAL in old location, so keep it around until HAL is updated.
 	%{_bindir}/dellWirelessCtl
 	
 	# data files
@@ -338,7 +335,7 @@ cat > files-smbios-utils-python <<-EOF
 EOF
 
 cat > files-yum-dellsysid <<-EOF
-	%doc COPYING-GPL COPYING-OSL README
+	%doc COPYING-GPL COPYING-OSL
 	# YUM Plugin
 	%config(noreplace) %{_sysconfdir}/yum/pluginconf.d/*
 	%{_exec_prefix}/lib/yum-plugins/*
@@ -368,7 +365,7 @@ rm -rf %{buildroot}
 
 %files -n libsmbios-devel -f _build/buildlogs.txt
 %defattr(-,root,root,-)
-%doc COPYING-GPL COPYING-OSL README src/bin/getopts_LICENSE.txt src/include/smbios/config/boost_LICENSE_1_0_txt
+%doc COPYING-GPL COPYING-OSL src/bin/getopts_LICENSE.txt src/include/smbios/config/boost_LICENSE_1_0_txt
 %{_includedir}/smbios
 %{_includedir}/smbios_c
 %{_libdir}/libsmbios.so
@@ -380,22 +377,14 @@ rm -rf %{buildroot}
 %files -n smbios-utils
 # opensuse 11.1 enforces non-empty file list :(
 %defattr(-,root,root,-)
-%doc COPYING-GPL COPYING-OSL README
+%doc COPYING-GPL COPYING-OSL
 # no other files.
 
 %files -n smbios-utils-bin
 %defattr(-,root,root,-)
-%doc COPYING-GPL COPYING-OSL README
+%doc COPYING-GPL COPYING-OSL
 %doc src/bin/getopts_LICENSE.txt src/include/smbios/config/boost_LICENSE_1_0_txt
-%doc doc/pkgheader.sh
-#
-# legacy C++
-%{_sbindir}/dellBiosUpdate-compat
-%{_sbindir}/dellLEDCtl
-%ifnarch ia64
-%{_sbindir}/dellMediaDirectCtl
-%endif
-#
+
 # new C utilities
 %{_sbindir}/smbios-state-byte-ctl
 %{_sbindir}/smbios-get-ut-data

--- a/pkg/mk-rel-rpm.sh
+++ b/pkg/mk-rel-rpm.sh
@@ -32,5 +32,3 @@ for i in *.tar.{gz,bz2} *.zip *.src.rpm; do
     [ ! -e $DEST/$(basename $i) ] || continue
     cp $i $DEST
 done
-
-git push --tags origin master:master

--- a/pkg/mk-rel-rpm.sh
+++ b/pkg/mk-rel-rpm.sh
@@ -21,14 +21,3 @@ pushd _builddir
 ../autogen.sh
 make rpm RPM_DEFINES="--without unit-tests"
 make distcheck
-
-make git-tag
-eval "$(make get-version)"
-
-DEST=$LIBSMBIOS_TOPDIR/download/$PACKAGE/$PACKAGE-$PACKAGE_VERSION/
-mkdir -p $DEST
-for i in *.tar.{gz,bz2} *.zip *.src.rpm; do
-    [ -e $i ] || continue
-    [ ! -e $DEST/$(basename $i) ] || continue
-    cp $i $DEST
-done


### PR DESCRIPTION
This may be the wrong way to fix this but you are at least able to now build a working rpm file. I imagine the README was removed when going to github since it's now a README.md file. `smbios-rbu-bios-update` was removed because i just don't see it anymore and it throws an error when trying to add it (someone with more background should know if this is the correct action). I should fix `dellBiosUpdate` so it's not installed in two placed on the system.

The last update to this looks like it was 6 years ago which I believe is reason enough to drop some of the legacy support that is added into this package.

I normally don't run centos/rhel except on my livecd that provisions machines so I created a docker image that can be used to test out this change simply as well as encapsulates all the dependencies needed for building the package. You can use it very simply like so...

```
./pkg/build-dockerfile.sh centos6
mkdir output
docker run -v `pwd`/output:/output centos6-libsmbios
```

When you are done output should contain some rpm files that you can sync over to whatever system you need.

I am seeing if any open source build sites allow you to run this and then upload the artifacts to an environment... Will update if I find out.

EDIT: https://github.com/dell/libsmbios/pull/6/files#diff-c0c5894abe6a4c13110a2dbe2cdbaccf much of this was removed since it looks like it fed into some legacy system that was used for building the images before which is no longer in use.