### PR TITLE
Fix typo in smbios-keyboard-ctl (bee -> been)

### DIFF
--- a/src/bin/smbios-keyboard-ctl
+++ b/src/bin/smbios-keyboard-ctl
@@ -400,7 +400,7 @@ def PrintKeyBoardStatus():
         #Timeout value cbRes2 byte2 [5:0]
         timeout = get_byte(res[smi.cbRES2] ,3) & 0x3F
 
-        print _("\n Keyboard illumination timeout has bee set at: %d %s") % (timeout, time_unit)
+        print _("\n Keyboard illumination timeout has been set at: %d %s") % (timeout, time_unit)
         verboseLog.info ( _(" Note - Timeout value of 0 means its always ON "))
 
         #cbRes3 byte0


### PR DESCRIPTION
Just a minor typo fix.