### PR TITLE
use-after-free errors

### DIFF
--- a/src/libsmbios_c/smbios/smbios.c
+++ b/src/libsmbios_c/smbios/smbios.c
@@ -71,8 +71,14 @@ struct smbios_struct *smbios_get_next_struct_by_handle(const struct smbios_struc
 
 const char *smbios_strerror(const struct smbios_struct *cur)
 {
+    char *ret;
     struct smbios_table *table = smbios_table_factory(SMBIOS_DEFAULTS | SMBIOS_NO_ERR_CLEAR);
-    const char *ret = smbios_table_strerror(table);
-    smbios_table_free(table);
+    if (table) {
+        /* leak */
+        ret = strdup(smbios_table_strerror(table));
+        smbios_table_free(table);
+    } else {
+        ret = "";
+    }
     return ret;
 }

--- a/src/libsmbios_c/smbios/smbios_obj.c
+++ b/src/libsmbios_c/smbios/smbios_obj.c
@@ -96,7 +96,6 @@ struct smbios_table *smbios_table_factory(int flags, ...)
 out_init_fail:
     // fail. init_smbios_* functions are responsible for free-ing memory if they
     // return failure.
-    toReturn->initialized = 0;
     toReturn = 0;
 
 out:


### PR DESCRIPTION
At Ubuntu, we got Launchpad [bug #1663548](https://bugs.launchpad.net/ubuntu/+source/fwupd/+bug/1663548) (and dupes) saying that fwupd 0.8.0-2 (from Debian, uploaded by @superm1) was crashing.

```
#0  _int_malloc (av=av@entry=0x7f9048af2b00 <main_arena>, bytes=bytes@entry=72) at malloc.c:3413
#1  0x00007f90487b7c2b in __libc_calloc (n=<optimized out>, elem_size=<optimized out>) at malloc.c:3271
#2  0x00007f90494c5ea1 in g_malloc0 () from /tmp/apport_sandbox_jj8QDg/lib/x86_64-linux-gnu/libglib-2.0.so.0
No symbol table info available.
#3  0x00007f9049798d74 in g_closure_new_simple () from /tmp/apport_sandbox_jj8QDg/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0
No symbol table info available.
#4  0x00007f904979a330 in g_cclosure_new () from /tmp/apport_sandbox_jj8QDg/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0
No symbol table info available.
#5  0x00007f90497b2651 in g_signal_connect_data () from /tmp/apport_sandbox_jj8QDg/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0
No symbol table info available.
#6  0x00005562eb626eac in fu_main_load_plugins (error=0x7ffe1c0f0080, priv=0x5562ebfed830) at fu-main.c:2648
#7  main (argc=<optimized out>, argv=<optimized out>) at fu-main.c:2806
```

This looks very much like memory corruption is going on somewhere. I tried to valgrind fwupd, but didn't manage to get it to report any problems that way. Running fwupd with `--verbose` showed that the last thing it was doing before it was crashing was initialising its dell plugin. At that point I rebuilt libsmbios 2.3.1-0ubuntu2 with `-fsanitize=address` set, and that gave [this useful output](https://github.com/dell/libsmbios/files/788023/j.txt). 

It turns out there are a couple of areas where memory is freed but pointers to it are still around and are used by other parts of code. I fixed the ones that cause this crash. See the commit messages for more details - there's one place where I leak a string that someone who knows the code better might be able to fix without causing that (such as by returning pointers into a table and not allocating strings which are freed).
