### PR TITLE
Fix everything gcc 7's -Wextra and coverity find.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,22 @@ po/remove-potcdate.sin
 # docker build process
 /Dockerfile
 /*-entrypoint.sh
+
+AUTHORS
+ChangeLog
+Makefile
+config.log
+config.status
+libsmbios-*.tar.*
+*.spec
+*.pc
+libtool
+out/
+pkg/pkginfo
+pkg/test-driver
+po/POTFILES
+po/en@boldquot.insert-header
+po/en@quot.insert-header
+po/remove-potcdate.sed
+po/stamp-po
+src/python/_vars.py

--- a/Makefile.am
+++ b/Makefile.am
@@ -18,8 +18,8 @@ lib_LTLIBRARIES=
 TESTS=
 
 AM_CPPFLAGS = -I$(top_builddir)/out/include -I$(top_srcdir)/src/include -DLIBSMBIOS_LOCALEDIR=\"$(localedir)\"
-AM_CFLAGS = -Wall -fPIC
-AM_CXXFLAGS = -Wall -fPIC
+AM_CFLAGS = -Wall -Wextra -Wno-missing-field-initializers -Wno-unused-parameter -fPIC
+AM_CXXFLAGS = -Wall -Wextra -Wno-missing-field-initializers -Wno-unused-parameter -fPIC
 AM_LDADD = $(LIBINTL)
 
 AM_LDFLAGS = -L$(top_builddir)/out/

--- a/src/bin/smbios-get-ut-data.c
+++ b/src/bin/smbios-get-ut-data.c
@@ -177,7 +177,9 @@ void dumpMem( const char *fn, size_t offset, size_t len)
     memory_read(buf, offset, len);
     int recs = fwrite(buf, len, 1, fd);
     if (recs != 1)
+    {
         ; // nada
+    }
     free(buf);
     fclose(fd);
 }

--- a/src/include/smbios_c/smbios.h
+++ b/src/include/smbios_c/smbios.h
@@ -127,7 +127,7 @@ LIBSMBIOS_C_DLL_SPEC const char * smbios_struct_get_string_number(const struct s
  * Can return 0. The buffer used is guaranteed to be valid until the next call
  * to any smbios_* function. Copy the contents if you need it longer.
  */
-LIBSMBIOS_C_DLL_SPEC const char * smbios_strerror();
+LIBSMBIOS_C_DLL_SPEC char * smbios_strerror();
 
 EXTERN_C_END;
 

--- a/src/libsmbios_c++/cmos/CmosRW.cpp
+++ b/src/libsmbios_c++/cmos/CmosRW.cpp
@@ -118,6 +118,7 @@ namespace cmos
     //
     u8 CmosRWFile::readByte (u32 indexPort, u32 dataPort, u32 offset) const
     {
+        int ret;
         u8 retval = 0xFF;
         u32 realOffset = indexPort * 256 + offset;
         (void) dataPort; // unused
@@ -127,7 +128,12 @@ namespace cmos
         if( !fh )
             throw smbios::InternalErrorImpl(errMessage + strerror(errno));
 
-        fseek (fh, static_cast<long>(realOffset), SEEK_SET);
+        ret = fseek (fh, static_cast<long>(realOffset), SEEK_SET);
+        if (ret < 0)
+        {
+            fclose (fh);
+            throw std::exception();
+        }
         size_t numRecs = fread (&retval, sizeof (retval), 1, fh); // only used in unit tests, so isnt critical
         fclose (fh);
         if (numRecs != 1)
@@ -141,6 +147,7 @@ namespace cmos
     void CmosRWFile::writeByte (u32 indexPort, u32 dataPort, u32 offset, u8 byte) const
     {
         //cout << "w(" << offset << ")";
+        int ret;
         u32 realOffset = indexPort * 256 + offset;
         (void) dataPort; // unused
         string errMessage("Could not open CMOS file(" + fileName + ") for writing: ");
@@ -149,7 +156,12 @@ namespace cmos
         if( !fh )
             throw smbios::InternalErrorImpl(errMessage + strerror(errno));
 
-        fseek (fh, static_cast<long>(realOffset), SEEK_SET);
+        ret = fseek (fh, static_cast<long>(realOffset), SEEK_SET);
+        if (ret < 0)
+        {
+            fclose (fh);
+            throw std::exception();
+        }
         size_t recs = fwrite (&byte, sizeof (byte), 1, fh);
         fclose (fh);
         fflush(NULL);

--- a/src/libsmbios_c++/smi/SmiImpl.h
+++ b/src/libsmbios_c++/smi/SmiImpl.h
@@ -84,7 +84,9 @@ namespace smi
         };
         virtual void execute()
         {
-            fseek(fh,0,0);
+            int ret = fseek(fh,0,0);
+            if (ret < 0)
+                throw std::exception();
         };
         virtual void getResultBuffer(u8 *buffer, size_t size)
         {

--- a/src/libsmbios_c/cmos/cmos_obj.c
+++ b/src/libsmbios_c/cmos/cmos_obj.c
@@ -91,9 +91,9 @@ LIBSMBIOS_C_DLL_SPEC struct cmos_access_obj *cmos_obj_factory(int flags, ...)
     if (ret==0)
         goto out;
 
-    // fail. init_cmos_* functions are responsible for free-ing memory if they
-    // return failure.
     toReturn->initialized = 0;
+    if (toReturn != &singleton)
+        free(toReturn);
     toReturn = 0;
 
 out:

--- a/src/libsmbios_c/cmos/cmos_obj.c
+++ b/src/libsmbios_c/cmos/cmos_obj.c
@@ -155,16 +155,19 @@ out:
     return retval;
 }
 
-void __hidden _cmos_obj_cleanup(struct cmos_access_obj *m)
-{
-    if(m->cleanup)
-        m->cleanup(m);
-}
-
-void __hidden _cmos_obj_free(struct cmos_access_obj *m)
+void cmos_obj_free(struct cmos_access_obj *m)
 {
     struct callback *ptr = 0;
     struct callback *next = 0;
+
+    if (!m)
+        return;
+
+    if(m->cleanup)
+        m->cleanup(m);
+
+    if (m == &singleton)
+        return;
 
     ptr = m->cb_list_head;
     // free callback list
@@ -191,16 +194,6 @@ void __hidden _cmos_obj_free(struct cmos_access_obj *m)
 
     memset(m, 0, sizeof(*m)); // big hammer
     free(m);
-}
-
-void cmos_obj_free(struct cmos_access_obj *m)
-{
-    if (!m) goto out;
-    _cmos_obj_cleanup(m);
-    if (m != &singleton)
-        _cmos_obj_free(m);
-out:
-    return;
 }
 
 void cmos_obj_register_write_callback(struct cmos_access_obj *m, cmos_write_callback cb_fn, void *userdata, void (*destructor)(void *))

--- a/src/libsmbios_c/smbios/smbios.c
+++ b/src/libsmbios_c/smbios/smbios.c
@@ -69,7 +69,7 @@ struct smbios_struct *smbios_get_next_struct_by_handle(const struct smbios_struc
     return ret;
 }
 
-const char *smbios_strerror(const struct smbios_struct *cur)
+char *smbios_strerror(const struct smbios_struct *cur)
 {
     char *ret;
     struct smbios_table *table = smbios_table_factory(SMBIOS_DEFAULTS | SMBIOS_NO_ERR_CLEAR);

--- a/src/libsmbios_c/smbios/smbios_obj.c
+++ b/src/libsmbios_c/smbios/smbios_obj.c
@@ -104,14 +104,23 @@ out:
     return toReturn;
 }
 
-void smbios_table_free(struct smbios_table *m)
+void smbios_table_free(struct smbios_table *this)
 {
-    if (!m) goto out;
-    if (m != &singleton)
-        _smbios_table_free(m);
+    if (!this || this == &singleton)
+        return;
 
-out:
-    return;
+    memset(&this->tep, 0, sizeof(this->tep));
+
+    free(this->errstring);
+    this->errstring = 0;
+
+    free(this->table);
+    this->table = 0;
+
+    this->initialized=0;
+
+    memset(this, 0, sizeof(*this)); // big hammer
+    free(this);
 }
 
 const char *smbios_table_strerror(const struct smbios_table *m)
@@ -313,22 +322,6 @@ void smbios_table_walk(struct smbios_table *table, void (*fn)(const struct smbio
  * Internal functions
  *
  **************************************************/
-
-void __hidden _smbios_table_free(struct smbios_table *this)
-{
-    memset(&this->tep, 0, sizeof(this->tep));
-
-    free(this->errstring);
-    this->errstring = 0;
-
-    free(this->table);
-    this->table = 0;
-
-    this->initialized=0;
-
-    memset(this, 0, sizeof(*this)); // big hammer
-    free(this);
-}
 
 int __hidden init_smbios_struct(struct smbios_table *m)
 {

--- a/src/libsmbios_c/smbios/smbios_obj.c
+++ b/src/libsmbios_c/smbios/smbios_obj.c
@@ -432,7 +432,7 @@ bool __hidden validate_smbios_tep( const struct smbios_table_entry_point *tempTE
     fnprintf("SMBIOS TEP csum %d.\n", (int)checksum);
     if(checksum) // Checking entry point structure checksum
         retval = false;  // validation failed
-    if(! (tempTEP->major_ver!=0x02 || tempTEP->major_ver!=0x03) ) // Checking smbios major version
+    if(tempTEP->major_ver != 0x02 && tempTEP->major_ver != 0x03) // Checking smbios major version
         retval = false;  // validation failed
 
     // Entry Point Length field is at least 0x1f.

--- a/src/libsmbios_c/smi/smi_linux.c
+++ b/src/libsmbios_c/smi/smi_linux.c
@@ -59,6 +59,7 @@ u32 __hidden get_phys_buf_addr()
     FILE *fd = 0;
     u32 physaddr = 0;
     char linebuf[bufsize] = {0,};
+    int ret;
 
     fnprintf("\n");
 
@@ -68,7 +69,9 @@ u32 __hidden get_phys_buf_addr()
     if (!fd)
         goto out;
 
-    fseek(fd, 0L, 0);
+    ret = fseek(fd, 0L, 0);
+    if (ret < 0)
+        goto out_close;
     size_t numBytes = fread(linebuf, 1, bufsize, fd);
     if (!numBytes)
         goto out_close;

--- a/src/libsmbios_c/smi/smi_linux.c
+++ b/src/libsmbios_c/smi/smi_linux.c
@@ -90,7 +90,7 @@ out:
 u32 __hidden set_phys_buf_size(u32 newsize)
 {
     char fn[bufsize] = {0,};
-    FILE *fd = 0;
+    FILE *fd = NULL;
     char linebuf[bufsize] = {0,};
     u32 phys_buf_addr=0;
 
@@ -298,6 +298,8 @@ int __hidden LINUX_dell_smi_obj_execute(struct dell_smi_obj *this)
 
     // update smi buffer
     copy_phys_bufs(this, kernel_buf, physaddr, FROM_KERNEL_BUF);
+
+    fclose(fd);
 
     retval = 0;
     goto out;

--- a/src/libsmbios_c/smi/smi_obj.c
+++ b/src/libsmbios_c/smi/smi_obj.c
@@ -201,7 +201,7 @@ u8 * dell_smi_obj_make_buffer_frombios_withheader(struct dell_smi_obj *this, u8 
     if(buf)
     {
         // write buffer pattern
-        for (int i=0; i<size+4; i++)
+        for (unsigned int i=0; i<size+4; i++)
             buf[i] = bufpat[i%4];
 
         // write size of remaining bytes

--- a/src/libsmbios_c/smi/smi_obj.c
+++ b/src/libsmbios_c/smi/smi_obj.c
@@ -304,11 +304,16 @@ out_fail:
     fnprintf(" out_fail \n");
     retval = -1;
     errbuf = smi_get_module_error_buf();
-    if (errbuf){
+    if (errbuf) {
+        char *smberr = smbios_strerror();
         fnprintf("error: %s\n", error);
         strlcpy(errbuf, error, ERROR_BUFSIZE);
-        fnprintf("smbios_strerror: %s\n", smbios_strerror());
-        strlcat(errbuf, smbios_strerror(), ERROR_BUFSIZE);
+        if (smberr)
+        {
+            fnprintf("smbios_strerror: %s\n", smberr);
+            strlcat(errbuf, smberr, ERROR_BUFSIZE);
+            free(smberr);
+        }
     }
 
 out:

--- a/src/libsmbios_c/smi/smi_password.c
+++ b/src/libsmbios_c/smi/smi_password.c
@@ -177,43 +177,39 @@ out:
 
 int dell_smi_password_verify(int which, const char *password)
 {
-    int retval = 2;
     struct smi_password_properties p = {0,};
     int tmpret = get_password_properties_2(which, &p);
-    if (tmpret == 0 && p.installed != 0)
-        // if function succeeded and password *not* installed, skip
-        goto out;
-    else if (tmpret == 0)
+
+    // if function succeeded and password *not* installed, skip
+    if (tmpret == 0 && p.installed != SMI_PASSWORD_INSTALLED)
+        return 2;
+
+    if (tmpret == 0)
     {
-        // else _2 function is valid, so use it.
         tmpret = verify_password_2(which, password, p.maxlen, 0);
-        retval = 1;
-        if (tmpret==0) // correct, security key set
-            goto out;
+        if (tmpret == SMI_PASSWORD_CORRECT) // correct, security key set
+            return 1;
 
-        retval = 0; // incorrect password
-        if (tmpret==2)
-            goto out;
+        if (tmpret == SMI_PASSWORD_INCORRECT)
+            return 0;
     }
-
 
     tmpret = password_installed(which);
-    if (tmpret == 0 && tmpret == 2)
-        // function succeeded and password not installed
-        goto out;
-    else if (tmpret == 0)
+    // function succeeded and password not installed
+    if (!(tmpret == 0 || tmpret == 2))
+        return 2;
+
+    if (tmpret == 0)
     {
         tmpret = verify_password(which, password, 0);
-        retval = 1;
-        if (tmpret==0) // correct, security key set
-            goto out;
-        retval = 0; // incorrect password
-        if (tmpret==2)
-            goto out;
+        if (tmpret == SMI_PASSWORD_CORRECT) // correct, security key set
+            return 1;
+
+        if (tmpret == SMI_PASSWORD_INCORRECT)
+            return 0;
     }
 
-out:
-    return retval;
+    return 2;
 }
 
 int dell_smi_password_format(int which)

--- a/src/libsmbios_c/smi/smi_password.c
+++ b/src/libsmbios_c/smi/smi_password.c
@@ -294,7 +294,7 @@ int verify_password(int which, const char *password_scancodes, u16 *security_key
 
     // copy password into arg
     if (password_scancodes)
-        for (int i=0; i<strlen(password_scancodes) && i < sizeof(arg); ++i)
+        for (unsigned int i=0; i<strlen(password_scancodes) && i < sizeof(arg); ++i)
             ((u8*)arg)[i] = password_scancodes[i];
 
     dell_smi_obj_set_arg(smi, cbARG1, arg[0]);
@@ -322,11 +322,11 @@ int change_password(int which, const char *oldpw_scancode, const char *newpw_sca
 
     // copy password into arg
     if (oldpw_scancode)
-        for (int i=0; i<strlen(oldpw_scancode) && i < sizeof(arg)/2; ++i)
+        for (unsigned int i=0; i<strlen(oldpw_scancode) && i < sizeof(arg)/2; ++i)
             ((u8*)arg)[i] = oldpw_scancode[i];
 
     if (newpw_scancode)
-        for (int i=0; i<strlen(newpw_scancode) && i < sizeof(arg)/2; ++i)
+        for (unsigned int i=0; i<strlen(newpw_scancode) && i < sizeof(arg)/2; ++i)
             ((u8*)arg)[i + sizeof(arg)/2 ] = newpw_scancode[i];
 
     dell_smi_obj_set_arg(smi, cbARG1, arg[0]);

--- a/src/libsmbios_c/smi/smi_solaris.c
+++ b/src/libsmbios_c/smi/smi_solaris.c
@@ -59,6 +59,7 @@ u32 __internal get_phys_buf_addr()
     FILE *fd = 0;
     u32 physaddr = 0;
     char linebuf[bufsize] = {0,};
+    int ret;
 
     fnprintf("\n");
 
@@ -68,7 +69,10 @@ u32 __internal get_phys_buf_addr()
     if (!fd)
         goto out;
 
-    fseek(fd, 0L, 0);
+    ret = fseek(fd, 0L, 0);
+    if (ret < 0)
+        goto out_close;
+
     size_t numBytes = fread(linebuf, 1, bufsize, fd);
     if (!numBytes)
         goto out_close;

--- a/src/libsmbios_c/system_info/asset_tag.c
+++ b/src/libsmbios_c/system_info/asset_tag.c
@@ -128,25 +128,20 @@ LIBSMBIOS_C_DLL_SPEC char *sysinfo_get_asset_tag()
         // first function to return non-zero id with strlen()>0 wins.
         assetTag = DellAssetTagFunctions[i].f_ptr ();
         fnprintf("got result: %p\n", assetTag);
-        if (assetTag)
+        if (!assetTag)
+            continue;
+
+        strip_trailing_whitespace(assetTag);
+        if (!strlen(assetTag))
         {
-            strip_trailing_whitespace(assetTag);
-            if (!strlen(assetTag))
-            {
-                fnprintf("string is zero len, returning as not specified\n");
-                /*
-                 * In case one of the function returns an empty string (zero len),
-                 * we would be returning the value "Not Specified" to the caller.
-                 */
-                assetTag = realloc(assetTag, ASSET_TAG_NOT_SPECIFIED_LEN);
-                if (assetTag)
-                    strncpy(assetTag, ASSET_TAG_NOT_SPECIFIED, ASSET_TAG_NOT_SPECIFIED_LEN - 1);
-                goto out;
-            }
+            fnprintf("string is zero len, not using it\n");
+            free(assetTag);
+            assetTag = NULL;
         }
     }
 
-out:
+    if (!assetTag)
+        assetTag = strdup(ASSET_TAG_NOT_SPECIFIED);
     return assetTag;
 }
 

--- a/src/libsmbios_c/system_info/id_byte.c
+++ b/src/libsmbios_c/system_info/id_byte.c
@@ -222,7 +222,8 @@ LIBSMBIOS_C_DLL_SPEC int sysinfo_get_dell_oem_system_id()
     sysinfo_clearerr();
     for (int i = 0; i < numEntries; ++i)
     {
-        fnprintf("calling id_byte function: %s\n", DellIdByteFunctions[i].name);
+        fnprintf("calling id_byte function: %s\n",
+                 DellOemIdByteFunctions[i].name);
         // first function to return non-zero id wins.
         systemId = DellOemIdByteFunctions[i].f_ptr ();
 

--- a/src/libsmbios_c/system_info/service_tag.c
+++ b/src/libsmbios_c/system_info/service_tag.c
@@ -146,7 +146,7 @@ static void dell_encode_service_tag( char *tag, size_t len )
     newTagBuf[4] = newTagBuf[4] | dell_encode_digit(tagToSet[6]);
 
     memset(tag, 0, len);
-    memcpy(tag, newTagBuf, len < SVC_TAG_CMOS_LEN_MAX ? len: SVC_TAG_CMOS_LEN_MAX);
+    memcpy(tag, newTagBuf, SVC_TAG_CMOS_LEN_MAX);
     return;
 }
 

--- a/src/libsmbios_c/system_info/up_flag.c
+++ b/src/libsmbios_c/system_info/up_flag.c
@@ -57,7 +57,12 @@ __hidden bool get_up_offset_and_flag(struct up_info *up)
         offset = memory_search( UP_ANCHOR, UP_ANCHOR_LEN,  0xF0000UL, 0xFFFFFUL, 1);
 
     if (offset!=0 && offset!=-1)
-        memory_read(up, (u64)offset, sizeof(*up));
+    {
+        int ret;
+        ret = memory_read(up, (u64)offset, sizeof(*up));
+        if (ret < 0)
+            return false;
+    }
 
     fnprintf("offset 0x%llx", offset);
     return (offset!=0 && offset!=-1);

--- a/src/libsmbios_c/token/checksum.c
+++ b/src/libsmbios_c/token/checksum.c
@@ -46,7 +46,7 @@ __hidden int update_checksum(const struct cmos_access_obj *c, bool do_update, vo
     fnprintf(" calculated 0x%x\n", wordRetval);
 
     u32 actualcsum = 0;
-    for( int i=0; i<data->csumlen; ++i )
+    for( unsigned int i=0; i<data->csumlen; ++i )
     {
         u8 byte;
         int ret = cmos_obj_read_byte(c, &byte, data->indexPort, data->dataPort, data->csumloc+i);
@@ -70,7 +70,7 @@ __hidden int update_checksum(const struct cmos_access_obj *c, bool do_update, vo
     {
         // write new checksum
         fnprintf("REWRITE CSUM\n");
-        for( int i=0; i<data->csumlen; ++i )
+        for( unsigned int i=0; i<data->csumlen; ++i )
         {
             int ret = cmos_obj_write_byte(c, data->indexPort, data->dataPort, data->csumloc+i, csum[data->csumlen -i -1]);
             if (ret)

--- a/src/libsmbios_c/token/token.c
+++ b/src/libsmbios_c/token/token.c
@@ -40,24 +40,27 @@ const char * token_strerror()
     const char *retval = 0;
     struct token_table *table = token_table_factory(TOKEN_DEFAULTS | TOKEN_NO_ERR_CLEAR);
     fnprintf("\n");
-    if (table)
+    if (table) {
         retval = token_table_strerror(table);
+        free(table);
+    }
     return retval;
 }
 
-#define make_token_fn(ret, defret, callname)\
-    ret token_##callname (u16 id)    \
-    {\
-        struct token_table *table = 0;              \
-        const struct token_obj *token = 0;          \
-        fnprintf("\n"); \
-        table = token_table_factory(TOKEN_DEFAULTS); \
-        if (!table) goto out;                       \
-        token = token_table_get_next_by_id(table, 0, id); \
-        if (!token) goto out;                       \
-        return token_obj_##callname (token);                    \
-out:\
-        return defret;  \
+#define make_token_fn(ret, defret, callname)                \
+    ret token_##callname (u16 id)                           \
+    {                                                       \
+        struct token_table *table = 0;                      \
+        const struct token_obj *token = 0;                  \
+        fnprintf("\n");                                     \
+        table = token_table_factory(TOKEN_DEFAULTS);        \
+        if (!table) goto out;                               \
+        token = token_table_get_next_by_id(table, 0, id);   \
+        free(table);                                        \
+        if (!token) goto out;                               \
+        return token_obj_##callname (token);                \
+out:                                                        \
+        return defret;                                      \
     }
 
 make_token_fn(int, 0, get_type)

--- a/src/libsmbios_c/token/token_d4.c
+++ b/src/libsmbios_c/token/token_d4.c
@@ -318,7 +318,7 @@ int __hidden add_d4_tokens(struct token_table *table)
                 continue;
             }
 
-            if ( (void* )(token + sizeof(*token) ) > (void *)(d4_struct + d4_struct->length ))
+            if ( (void *)(token + 1) > (void *)(d4_struct + d4_struct->length))
             {
                 fnprintf("\n");
                 fnprintf("\n");

--- a/src/libsmbios_c/token/token_d4.c
+++ b/src/libsmbios_c/token/token_d4.c
@@ -165,7 +165,7 @@ static char * _d4_get_string(const struct token_obj *t, size_t *len)
     if (!retval)
         goto out_err;
 
-    for (int i=0; i<strSize; ++i){
+    for (unsigned int i=0; i<strSize; ++i){
         fnprintf("read byte %d/%zd\n", i+1, strSize);
         int ret = cmos_read_byte(retval + i,
                   cast_struct(t)->indexPort,
@@ -206,7 +206,7 @@ static int _d4_set_string(const struct token_obj *t, const char *str, size_t siz
 
     memcpy( targetBuffer, str, size < strSize ? size : strSize );
 
-    for (int i=0; i<strSize; ++i){
+    for (unsigned int i=0; i<strSize; ++i){
         int ret = cmos_write_byte(targetBuffer[i],
                   cast_struct(t)->indexPort,
                   cast_struct(t)->dataPort,

--- a/src/libsmbios_c/token/token_da.c
+++ b/src/libsmbios_c/token/token_da.c
@@ -209,7 +209,7 @@ int __hidden add_da_tokens(struct token_table *table)
                 continue;
             }
 
-            if ( (void* )(token + sizeof(*token) ) > (void *)(da_struct + da_struct->length ))
+            if ( (void *)(token + 1) > (void *)(da_struct + da_struct->length))
             {
                 fnprintf("\n");
                 fnprintf("\n");

--- a/src/libsmbios_c/token/token_obj.c
+++ b/src/libsmbios_c/token/token_obj.c
@@ -38,7 +38,7 @@
 
 // forward declarations
 static int init_token_table(struct token_table *);
-static void _token_table_free(struct token_table *);
+static void _token_table_free_tokens(struct token_table *this);
 
 // static vars
 static struct token_table singleton; // auto-init to 0
@@ -101,14 +101,20 @@ out:
     return toReturn;
 }
 
-
 void token_table_free(struct token_table *m)
 {
     fnprintf("\n");
-    if (m && m != &singleton)
-        _token_table_free(m);
 
     // can do special cleanup for singleton, but none necessary atm
+    if (!m || m == &singleton)
+        return;
+
+    _token_table_free_tokens(m);
+
+    free(m->errstring);
+    m->errstring = 0;
+
+    free(m);
 }
 
 const char * token_table_strerror(const struct token_table *table)
@@ -237,16 +243,6 @@ static void _token_table_free_tokens(struct token_table *this)
     }
 
     this->list_head = 0;
-}
-
-static void _token_table_free(struct token_table *this)
-{
-    _token_table_free_tokens(this);
-
-    free(this->errstring);
-    this->errstring = 0;
-
-    free(this);
 }
 
 void __hidden add_token(struct token_table *t, struct token_obj *o)


### PR DESCRIPTION
This patch series aims to clean up some bugs discovered with build-time analysis tools:
- it adds -Wextra to gcc command lines
- It fixes everything -Wextra complains about except for some minor selected categories that are excluded
- it fixes almost everything Coverity's cov-build finds when we build without --enable-libsmbios_cxx

The one Coverity complaint that's left after this PR is an error; covscan believes setup_d4_checksum() is leaking the allocation for "c", because it doesn't recognize the bimodality of cmos_obj_factory()'s singleton, because that code isn't visible while building token_d4.c .