### PR TITLE
Introduce WMI support for libsmbios

### DIFF
--- a/src/libsmbios_c/smi/wmi.h
+++ b/src/libsmbios_c/smi/wmi.h
@@ -1,0 +1,73 @@
+/*
+ *  User API methods for ACPI-WMI mapping driver
+ *
+ *  Copyright (C) 2017 Dell, Inc.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2 as
+ *  published by the Free Software Foundation.
+ */
+#ifndef _LINUX_WMI_H
+#define _LINUX_WMI_H
+
+#include <linux/ioctl.h>
+#include <linux/types.h>
+
+/* WMI bus will filter all WMI vendor driver requests through this IOC */
+#define WMI_IOC 'W'
+
+/* All ioctl requests through WMI should declare their size followed by
+ * relevant data objects
+ */
+struct wmi_ioctl_buffer {
+	__u64	length;
+	__u8	data[];
+};
+
+/* This structure may be modified by the firmware when we enter
+ * system management mode through SMM, hence the volatiles
+ */
+struct calling_interface_buffer {
+	__u16 cmd_class;
+	__u16 cmd_select;
+	__volatile__ __u32 input[4];
+	__volatile__ __u32 output[4];
+} __attribute__((packed));
+
+struct dell_wmi_extensions {
+	__u32 argattrib;
+	__u32 blength;
+	__u8 data[];
+} __attribute__((packed));
+
+struct dell_wmi_smbios_buffer {
+	__u64 length;
+	struct calling_interface_buffer std;
+	struct dell_wmi_extensions	ext;
+} __attribute__((packed));
+
+/* Whitelisted smbios class/select commands */
+#define CLASS_TOKEN_READ	0
+#define CLASS_TOKEN_WRITE	1
+#define SELECT_TOKEN_STD	0
+#define SELECT_TOKEN_BAT	1
+#define SELECT_TOKEN_AC		2
+#define CLASS_FLASH_INTERFACE	7
+#define SELECT_FLASH_INTERFACE	3
+#define CLASS_ADMIN_PROP	10
+#define SELECT_ADMIN_PROP	3
+#define CLASS_INFO		17
+#define SELECT_RFKILL		11
+#define SELECT_APP_REGISTRATION	3
+#define SELECT_DOCK		22
+
+/* whitelisted tokens */
+#define CAPSULE_EN_TOKEN	0x0461
+#define CAPSULE_DIS_TOKEN	0x0462
+#define WSMT_EN_TOKEN		0x04EC
+#define WSMT_DIS_TOKEN		0x04ED
+
+/* Dell SMBIOS calling IOCTL command used by dell-smbios-wmi */
+#define DELL_WMI_SMBIOS_CMD	_IOWR(WMI_IOC, 0, struct dell_wmi_smbios_buffer)
+
+#endif

--- a/src/py-cli/cli.py
+++ b/src/py-cli/cli.py
@@ -23,6 +23,14 @@ Common problems are:\n\
           Linux  : run as 'root' user\n\
           Windows: run as 'administrator' user\n\
 \n\
+    -- dell-smbios-wmi driver not loaded \n\
+       Try loading the dell-smbios-wmi driver \n\
+          Linux : modprobe dell-smbios-wmi \n\
+\n\
+    -- Call filtered by Linux kernel \n\
+       Some functionality is natively supported \n\
+       by the Linux kernel \n\
+\n\
     -- dcdbas device driver not loaded.\n\
        Try loading the dcdbas driver\n\
           Linux  : modprobe dcdbas\n\


### PR DESCRIPTION
Kernel 4.15 will be merging a new kernel module **dell-smbios-wmi** that adds support to do SMI requests over an ACPI-WMI interrface from userspace.

It replaces the **dcdbas** interface currently in use by libsmbios.  Ideally libsmbios should support both, but prefer to use the WMI interface.

More information about the WMI module is available in this commit:
http://git.infradead.org/users/dvhart/linux-platform-drivers-x86.git/commit/f2645fa317b8905b8934f06a0601d5b7fa66aba0

