### PR TITLE
Force python to install to site-arch not site-packages

### DIFF
--- a/pkg/libsmbios.spec.in
+++ b/pkg/libsmbios.spec.in
@@ -219,7 +219,7 @@ ln -s smbios-lcd-brightness %{buildroot}/%{_sbindir}/dellLcdBrightness
 
 cat > files-python-smbios <<-EOF
 	%doc COPYING-GPL COPYING-OSL
-	%{python3_sitelib}/*
+	%{python3_sitearch}/*
 EOF
 
 cat > files-smbios-utils-python <<-EOF

--- a/src/python/Makefile.am
+++ b/src/python/Makefile.am
@@ -1,6 +1,6 @@
 # vim:noexpandtab:autoindent:tabstop=8:shiftwidth=8:filetype=make:nocindent:tw=0:
 
-pkgpythondir=$(pythondir)/libsmbios_c
+pkgpythondir=$(pyexecdir)/libsmbios_c
 
 if HAVE_PYTHON
 pkgpython_PYTHON = \


### PR DESCRIPTION
This works around multilib errors; you may want to fix it some other way instead, since this is an awfully blunt hammer.