### PR TITLE
Don't hardcode python paths

### DIFF
--- a/doc/example-py-cliprog
+++ b/doc/example-py-cliprog
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # vim:expandtab:autoindent:tabstop=4:shiftwidth=4:filetype=python:tw=0
 
   #############################################################################

--- a/pkg/scripts/HelperXml.py
+++ b/pkg/scripts/HelperXml.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # VIM declarations
 # vim:expandtab:autoindent:tabstop=4:shiftwidth=4:filetype=python:
 

--- a/pkg/scripts/genSmbiosDefs.py
+++ b/pkg/scripts/genSmbiosDefs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # vim:expandtab:autoindent:tabstop=4:shiftwidth=4:filetype=python:
 
 

--- a/pkg/scripts/makeXmlHeader.py
+++ b/pkg/scripts/makeXmlHeader.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # vim: et:ai:sw=4:ts=4:filetype=python:nocindent:
 
 import sys

--- a/pkg/scripts/tr-report.py
+++ b/pkg/scripts/tr-report.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python3
+#! /usr/bin/env python3
 # VIM declarations
 # vim:expandtab:autoindent:tabstop=4:shiftwidth=4:filetype=python:
 

--- a/src/bin/smbios-battery-ctl
+++ b/src/bin/smbios-battery-ctl
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # vim:expandtab:autoindent:tabstop=4:shiftwidth=4:filetype=python:tw=0
 
   #############################################################################

--- a/src/bin/smbios-keyboard-ctl
+++ b/src/bin/smbios-keyboard-ctl
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # vim:expandtab:autoindent:tabstop=4:shiftwidth=4:filetype=python:tw=0
 
   #############################################################################

--- a/src/bin/smbios-lcd-brightness
+++ b/src/bin/smbios-lcd-brightness
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # vim:expandtab:autoindent:tabstop=4:shiftwidth=4:filetype=python:tw=0
 
   #############################################################################

--- a/src/bin/smbios-passwd
+++ b/src/bin/smbios-passwd
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # vim:expandtab:autoindent:tabstop=4:shiftwidth=4:filetype=python:tw=0
 
   #############################################################################

--- a/src/bin/smbios-sys-info
+++ b/src/bin/smbios-sys-info
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # vim:expandtab:autoindent:tabstop=4:shiftwidth=4:filetype=python:tw=0
 
   #############################################################################

--- a/src/bin/smbios-thermal-ctl
+++ b/src/bin/smbios-thermal-ctl
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # vim:expandtab:autoindent:tabstop=4:shiftwidth=4:filetype=python:tw=0
 
   #############################################################################

--- a/src/bin/smbios-token-ctl
+++ b/src/bin/smbios-token-ctl
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # vim:expandtab:autoindent:tabstop=4:shiftwidth=4:filetype=python:tw=0
 
   #############################################################################

--- a/src/bin/smbios-wakeup-ctl
+++ b/src/bin/smbios-wakeup-ctl
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # vim:expandtab:autoindent:tabstop=4:shiftwidth=4:filetype=python:tw=0
 
   #############################################################################

--- a/src/bin/smbios-wireless-ctl
+++ b/src/bin/smbios-wireless-ctl
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # vim:expandtab:autoindent:tabstop=4:shiftwidth=4:filetype=python:tw=0
 
   #############################################################################

--- a/src/pyunit/TestLib.py
+++ b/src/pyunit/TestLib.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python3
+#! /usr/bin/env python3
 # VIM declarations
 # vim:expandtab:autoindent:tabstop=4:shiftwidth=4:filetype=python:
 

--- a/src/pyunit/testAll.py
+++ b/src/pyunit/testAll.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python3
+#! /usr/bin/env python3
 # VIM declarations
 # vim:tw=0:expandtab:autoindent:tabstop=4:shiftwidth=4:filetype=python:
 

--- a/src/pyunit/testMemory.py
+++ b/src/pyunit/testMemory.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # vim:expandtab:autoindent:tabstop=4:shiftwidth=4:filetype=python:
 """
 """

--- a/src/pyunit/testSmbios.py
+++ b/src/pyunit/testSmbios.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # vim:expandtab:autoindent:tabstop=4:shiftwidth=4:filetype=python:
 """
 """


### PR DESCRIPTION
Fix `/usr/bin/python3: bad interpreter: No such file or directory` error