### PR TITLE
Don't abort dumping tokens on first error

### DIFF
--- a/src/bin/smbios-battery-ctl
+++ b/src/bin/smbios-battery-ctl
@@ -6,6 +6,7 @@
 # Copyright (c) 2016 Dell Computer Corporation
 # by Srinivas Gowda <srinivas_g_gowda@dell.com>
 # Dual Licenced under GNU GPL and OSL
+# Contributor: (c) 2019 Marcin Mielniczuk <marmistrz dot dev at zoho dot eu>
 #
 #############################################################################
 """smbios-battery-ctl"""

--- a/src/bin/smbios-token-ctl
+++ b/src/bin/smbios-token-ctl
@@ -5,6 +5,7 @@
   #
   # Copyright (c) 2005 Dell Computer Corporation
   # Dual Licenced under GNU GPL and OSL
+  # Contributor: (c) 2019 Marcin Mielniczuk <marmistrz dot dev at zoho dot eu>
   #
   #############################################################################
 """smbios-token-ctl"""
@@ -229,6 +230,8 @@ def dumpTokens(tokenTable, tokenXlator, options):
             print(_("  value: %s = %s") % (type, cli.makePrintable(value)))
         except RuntimeError as e:
             pass
+        except smbios_token.TokenManipulationFailure as e:
+            print(f"  value: token query failed: {e}")
 
         desc = _("   Desc: ")
         sys.stdout.write(desc)
@@ -424,6 +427,8 @@ def main():
         verboseLog.info( _("The token library returned this error:") )
         verboseLog.info( str(e) )
         moduleLog.info( cli.standardFailMessage )
+    except StopIteration:
+        pass
 
     return exit_code
 
@@ -468,4 +473,3 @@ INTERNAL_BLACKLIST = \
 
 if __name__ == "__main__":
     sys.exit( main() )
-


### PR DESCRIPTION
Closes #55. Closes #56.

I can't get decent error messages. 
```
  Token: 0x007d - LCD Brightness (Value)
  value: token query failed: b'Low level SMI call failed.\n\xe0\xc0\xe0h\x7fU'
   Desc: When Mobile Power Management is Enabled, the system will force the LCD 
         brightness to the value specified in this field. This attribute require
         s special handling.

```
Please confirm if it's a bug in `smbios_token.py`, if yes: I'll leave it as it is.



Btw. I fixed an awful `StopIteration` message:
```
$ sudo smbios-token-ctl -i 0x0343        
================================================================================
  Token: 0x0343 - Primary Battery Charge Configuration (Custom Charge)
  value: bool = true
   Desc: The battery will start and stop charging based on user input
Traceback (most recent call last):
  File "/usr/lib/python3.7/site-packages/libsmbios_c/smbios_token.py", line 134, in __iter__
    raise StopIteration
StopIteration

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/bin/smbios-token-ctl", line 470, in <module>
    sys.exit( main() )
  File "/usr/bin/smbios-token-ctl", line 377, in main
    dumpTokens(tokenTable, tokenXlator, options)
  File "/usr/bin/smbios-token-ctl", line 213, in dumpTokens
    for token in tokenTable:
RuntimeError: generator raised StopIteration
```