### PR TITLE
Fix bashism in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -116,7 +116,7 @@ AC_PROG_INSTALL
 
 dnl Check for python support
 AM_CONDITIONAL([HAVE_PYTHON], [false])
-if test x$wantpython == xyes ; then
+if test x$wantpython = xyes ; then
     AM_PATH_PYTHON([3.0],,[:])
     AM_CONDITIONAL([HAVE_PYTHON], [test "$PYTHON" != :])
 fi


### PR DESCRIPTION
This won't fix building with other shells because of #89, but it does fix configuring.