### PR TITLE
Don't rely on support for indirect expansion in the shell

### DIFF
--- a/Makefile-std
+++ b/Makefile-std
@@ -38,7 +38,7 @@ install-data-hook:
 	    file=$(DESTDIR)/$$i                     ;\
 	    for var in $(REPLACE_VARS)	;\
 	    do	\
-	        perl -p -i -e "s|^$$var\s*=.*|$$var=\"$${!var}\"|"  $$file;\
+	        var="$$var" perl -p -i -e 's|^\Q$$ENV{var}\E\s*=.*|$$ENV{var}="$$ENV{$$ENV{var}}"|'  $$file;\
 	    done	;\
 	done
 
@@ -48,7 +48,7 @@ install-exec-hook:
 	    file=$(DESTDIR)/$$i                     ;\
 	    for var in $(REPLACE_VARS)	;\
 	    do	\
-	        perl -p -i -e "s|^$$var\s*=.*|$$var=\"$${!var}\"|"  $$file;\
+	        var="$$var" perl -p -i -e 's|^\Q$$ENV{var}\E\s*=.*|$$ENV{var}="$$ENV{$$ENV{var}}"|'  $$file;\
 	    done	;\
 	done
 

--- a/src/python/Makefile.am
+++ b/src/python/Makefile.am
@@ -29,5 +29,5 @@ src/python/_vars.py: src/python/libsmbios_c/_vars.py  configure Makefile config.
 	cp $< $@
 	for var in $(REPLACE_VARS)	;\
 	do	\
-		perl -p -i -e "s|^$$var\s*=.*|$$var=\"$${!var}\"|"  $@;\
+		var="$$var" perl -p -i -e 's|^\Q$$ENV{var}\E\s*=.*|$$ENV{var}="$$ENV{$$ENV{var}}"|'  $@;\
 	done


### PR DESCRIPTION
POSIX does not define the indirect expansion syntax. Moreover, if going
to the trouble of executing Perl, one may as well take full advantage of
it. Address the issue by first having the shell export the variable.
Next, have Perl perform the replacement without utilising any form of
code injection. Instead, export 'var' into Perl's environment. That
way, Perl can reference the variable name as $ENV{var} and its value as
$ENV{$ENV{var}}.

Signed-off-by: Kerin Millar <kfm@plushkava.net>
Closes: https://bugs.gentoo.org/715202
Closes: https://github.com/dell/libsmbios/issues/89
Signed-off-by: Lars Wendler <polynomial-c@gentoo.org>