### PR TITLE
Fix the TokenTable iterator implementation

### DIFF
--- a/src/bin/smbios-token-ctl
+++ b/src/bin/smbios-token-ctl
@@ -427,8 +427,6 @@ def main():
         verboseLog.info( _("The token library returned this error:") )
         verboseLog.info( str(e) )
         moduleLog.info( cli.standardFailMessage )
-    except StopIteration:
-        pass
 
     return exit_code
 

--- a/src/python/libsmbios_c/smbios_token.py
+++ b/src/python/libsmbios_c/smbios_token.py
@@ -131,7 +131,7 @@ class _TokenTable(ctypes.Structure):
             if bool(cur):
                 yield cur.contents
             else:
-                raise StopIteration
+                return
 
     @traceLog()
     def __getitem__(self, id):


### PR DESCRIPTION
The `__iter__` function must perform initialization and return the iterator
object itself. The `__next__` function must return the next item or raise
StopIteration when no more elements are available.

This fixes the StopIteration exception being uncaught by the for loop when
the iterator reaches the end of the collection. This could be encountered
when calling `smbios-token-ctl --dump-tokens`.