### PR TITLE
pkg/mk-rel-rpm.sh: fix make command when CI is undefined.

### DIFF
--- a/pkg/mk-rel-rpm.sh
+++ b/pkg/mk-rel-rpm.sh
@@ -17,6 +17,7 @@ mkdir _builddir
 pushd _builddir
 ../autogen.sh
 if [ -n "$CI" ]; then
-	CI="CI=--define '_with_unit_tests 1'"
+    make rpm CI="--define '_with_unit_tests 1'"
+else
+    make rpm
 fi
-make rpm "$CI"


### PR DESCRIPTION
`pkg/mk-rel-rpm.sh` fails to build RPMs when `CI` is undefined, as the resulting command (`make rpm ""`) includes an extraneous emtpy string at the end, and fails with the following error:
```
make: *** empty string invalid as file name.  Stop.
```