### PR TITLE
add autopoint to requirements in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ To build a libsmbios tarball, you will need the following dependencies, in which
 1. libxml
 1. autoconf
 2. automake
-3. gettext
-4. libtool
+3. autopoint
+4. gettext
+5. libtool
 
 Building
 --


### PR DESCRIPTION
without it the following occurs
```
root@emu-blade:~/libsmbios# ./autogen.sh     # autogen.sh internally runs configure automatically
autoreconf: Entering directory `.'
autoreconf: running: autopoint --force
Can't exec "autopoint": No such file or directory at /usr/share/autoconf/Autom4te/FileUtils.pm line 345.
autoreconf: failed to run autopoint: No such file or directory
autoreconf: autopoint is needed because this package uses Gettext
```
but after installing autopoint, which is not in the readme, with
```
root@emu-blade:~/libsmbios#  sudo apt-get install autopoint
```

the build started working:
```
root@emu-blade:~/libsmbios# ./autogen.sh     # autogen.sh internally runs configure automatically
autoreconf: Entering directory `.'
autoreconf: running: autopoint --force
Copying file ABOUT-NLS
Copying file pkg/config.rpath
Creating directory m4
Copying file m4/codeset.m4
Copying file m4/gettext.m4
```