### PR TITLE
drop unittest.makeSuite (dropped in python 3.13)

### DIFF
--- a/src/pyunit/TestLib.py
+++ b/src/pyunit/TestLib.py
@@ -21,12 +21,10 @@ def parseOptions(*args):
     pass
 
 def runTests( testCase ):
-    testToRun = 'test'
-
     myTestSuite = unittest.TestSuite()
     for i in testCase:
         try:
-            temp = unittest.makeSuite( i, testToRun )
+            temp = unittest.defaultTestLoader.loadTestsFromTestCase( i )
             myTestSuite.addTest(temp)
         except ValueError:
             pass


### PR DESCRIPTION
It was deprecated already in python 3.11. I substituted it with `unittest.defaultTestLoader.loadTestsFromTestCase`, which is present since python 2.7.